### PR TITLE
Sessions metadata key was not expiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,14 @@ bin
 .classpath
 target
 .DS_Store
+
+### Intellij ###
+.idea/
+*.iml
+modules.xml
+
+## File-based project format:
+*.iws
+
+# JIRA plugin
+atlassian-ide-plugin.xml

--- a/src/main/java/com/webonise/tomcat8/redisession/RedisSessionManager.java
+++ b/src/main/java/com/webonise/tomcat8/redisession/RedisSessionManager.java
@@ -37,8 +37,8 @@ public class RedisSessionManager extends RedisSessionManagerBase {
     setTimeout(config.getInt("redis.timeout", Redis.DEFAULT_TIMEOUT));
     setDatabase(config.getInt("redis.database", Redis.DEFAULT_DATABASE));
     setPassword(config.getString("redis.password"));
-    setMaxInactiveInterval(config.getInt("redis.max.inactive", (int) TimeUnit.HOURS.toSeconds(1)));
-    
+    setMaxInactiveInterval(config.getInt("redis.max.inactive", Long.valueOf(TimeUnit.HOURS.toSeconds(1)).intValue()));
+    setMetakeyExpire(config.getInt("redis.metakey.expire", Long.valueOf(TimeUnit.HOURS.toSeconds(1)).intValue()));
     startRedis();
   }
 


### PR DESCRIPTION
To help control the expiration of the metadata use
redis.metakey.expire=3600
The default is 1 hour or 3600 seconds
